### PR TITLE
[SYNC] wrapped-bitcoin

### DIFF
--- a/crypto/wrapped-bitcoin@solana.json
+++ b/crypto/wrapped-bitcoin@solana.json
@@ -5,7 +5,7 @@
   "type": "token",
   "name": "Wrapped Bitcoin",
   "symbol": "WBTC",
-  "address": "3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh",
+  "address": "5XZw2LKTyrfvfiskJ78AMpackRjPcyCif1WhUsPDuVqQ",
   "decimals": 8,
   "logo": "wrapped-bitcoin.svg",
   "coingecko": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Overview**
> **[SYNC] wrapped-bitcoin** — refreshes the Solana WBTC catalog entry so it points at the current on-chain mint.
> 
> The only change is the `address` field in `crypto/wrapped-bitcoin@solana.json`, from `3NZ9JMVBmGAqocybic2c7LQCJScmgsAZ6vQqTDzcqmJh` to `5XZw2LKTyrfvfiskJ78AMpackRjPcyCif1WhUsPDuVqQ`. Metadata (symbol, decimals, CoinGecko/CMC ids, logo) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8cca964f2b1f2ffc5c019c3517976449e0a79e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->